### PR TITLE
Fix textareas and tinymce wysiwig

### DIFF
--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,4 +1,5 @@
 #= require active_admin/base
 #= require tinymce
 #= require tinymce-jquery
-tinyMCE.init selector: 'textarea'
+if location.pathname == "/admin/blogs/new"
+  tinyMCE.init selector: 'textarea'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170703101833) do
+ActiveRecord::Schema.define(version: 20170703110422) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -125,4 +125,5 @@ ActiveRecord::Schema.define(version: 20170703101833) do
     t.datetime "updated_at",  null: false
     t.integer  "order"
   end
+
 end


### PR DESCRIPTION
Fix text areas and TinyMCE WYSIWYG

To enable a WYSIWYG editor for creating a new blog story, we had to target the `text area`. However, _TinyMCE_ loads the script for all `text area`s in the admin namespace. We will like to only load _TinyMCE_ if we want to create a new blog.

This change addresses the need by:

* Targeting `text area`s for _TinyMCE_ only if we are on the `admin_new_blog_path`