### PR TITLE
Add featured to blogs

### DIFF
--- a/app/admin/blog.rb
+++ b/app/admin/blog.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Blog do
 #
 #
   permit_params do
-    permitted = [:author_id, :title, :story]
+    permitted = %i(author_id title story featured featured_image_url)
     params[:blog][:author_id] = current_admin_user.id if params[:blog]
     permitted
   end
@@ -30,6 +30,8 @@ ActiveAdmin.register Blog do
       row :story do |blog|
         blog.story.html_safe
       end
+      row :featured_image_url
+      row :featured
       row :created_at
       row "Last Update" do |blog|
         blog.updated_at

--- a/app/admin/blog.rb
+++ b/app/admin/blog.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Blog do
     column :author
     column :title
     column "Content", :story do |blog|
-      blog.story.html_safe
+      (ActionView::Base.full_sanitizer.sanitize(blog.story[0...100]) + "...")
     end
     column :created_at
     column "Last Update", :updated_at

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,5 +1,6 @@
 #= require active_admin/base
 #= require tinymce
 #= require tinymce-jquery
-if location.pathname == "/admin/blogs/new"
+regexp = /^\/admin\/blogs\/\d+\/edit$/
+if location.pathname == "/admin/blogs/new" || regexp.test(location.pathname)
   tinyMCE.init selector: 'textarea'

--- a/db/migrate/20170710122052_add_featured_to_blogs.rb
+++ b/db/migrate/20170710122052_add_featured_to_blogs.rb
@@ -1,0 +1,6 @@
+class AddFeaturedToBlogs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :blogs, :featured_image_url, :string
+    add_column :blogs, :featured, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170703110422) do
+ActiveRecord::Schema.define(version: 20170710122052) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -60,8 +60,10 @@ ActiveRecord::Schema.define(version: 20170703110422) do
     t.integer  "author_id"
     t.string   "title"
     t.text     "story"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "featured_image_url"
+    t.boolean  "featured"
   end
 
   create_table "inquiries", force: :cascade do |t|


### PR DESCRIPTION
Add featured images to blogs

We will like our blogs to be featured. It is imperative that they also have a featured image.

This change addresses the need by:

* Adding a `featured` boolean attribute and a `featured_image_url` string attribute to blogs